### PR TITLE
Skip hawkrest authentication if it's not detected and not mandatory.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -100,6 +100,17 @@ for some reason, set this:
 
     USE_CACHE_FOR_HAWK_NONCE = False  # only disable this if you need to
 
+If your api needs to support more than one authentication scheme, you can
+add this to your settings file:
+
+.. code-block:: python
+
+    HAWK_IS_MANDATORY = False
+
+With this setting Hakwrest will not complain if it doesn't detect a proper
+hawk HTTP_AUTHORIZATION header and the other authentication schemes in use will
+be checked.
+
 .. _`memcache`: https://docs.djangoproject.com/en/dev/topics/cache/#memcached
 .. _`prevent replay attacks`: http://mohawk.readthedocs.org/en/latest/usage.html#using-a-nonce-to-prevent-replay-attacks
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.test.utils import override_settings
 
 import mock
 from nose.tools import eq_
@@ -41,7 +42,20 @@ class TestAuthentication(AuthTest):
         with self.assertRaises(AuthenticationFailed) as exc:
             self.auth.authenticate(req)
 
-        eq_(exc.exception.detail, 'authentication failed')
+        eq_(exc.exception.detail, 'missing authorization header')
+
+    @override_settings(HAWK_IS_MANDATORY=False)
+    def test_missing_auth_header_not_mandatory(self):
+        req = self.factory.get('/')
+        with self.assertRaises(AuthenticationFailed) as exc:
+            self.auth.authenticate(req)
+
+        eq_(exc.exception.detail, 'missing authorization header')
+
+    @override_settings(HAWK_IS_MANDATORY=False)
+    def test_bad_auth_header_not_mandatory(self):
+        req = self.factory.get('/', HTTP_AUTHORIZATION='not really')
+        eq_(self.auth.authenticate(req), None)
 
     def test_hawk_get(self):
         sender = self._sender()


### PR DESCRIPTION
To allow hawkrest to play well with other authentication schemes
it should return None if a proper hawk HTTP_AUTHORIZATION header
is not detected.
To avoid breaking backward compatibility I hid the detection behind
a HAWK_IS_MANDATORY setting which defaults to True.
