### PR TITLE
Make AuthenticationFailed more specific for bad headers/expired tokens

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -27,7 +27,7 @@ class BaseTest(TestCase):
                           **kw)
 
     def _sender(self, method='GET', content_type='', url=None,
-                credentials=None, content=''):
+                credentials=None, content='', **kw):
         if not url:
             url = self.url
         if not credentials:
@@ -35,4 +35,5 @@ class BaseTest(TestCase):
         return Sender(credentials,
                       url, method,
                       content=content,
-                      content_type=content_type)
+                      content_type=content_type,
+                      **kw)


### PR DESCRIPTION
Whilst many of the possible mohawk exception types should not be revealed directly in the `AuthenticationFailed` exception message (since they would give clues to attackers - eg let them determine valid client ids), there are some that are useful (and safe) to surface in the response to the client.

Fixes #14.

The existing tests for the "dangerous to reveal" cases have also been updated to ensure they exact-match against the string, since previously they were only checking for the substring (since `assertRaisesRegexp()` uses `re.search()`).
