### PR TITLE
Update release publishing workflow to generate universal wheels

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -43,14 +43,17 @@ Publish a release
 
 To publish a new release on `PyPI`_, make sure the changelog is up to date
 and make sure you bumped the module version in ``setup.py``. Tag master
-at the version. For example, something like::
+as that version. For example, something like::
 
     git tag 0.0.5
     git push --tags
 
-Run this from the repository root to publish on `PyPI`_::
+Run this from the repository root to publish on `PyPI`_ as both a source
+distribution and wheel::
 
-    python setup.py sdist register upload
+    rm -rf dist/*
+    python setup.py sdist bdist_wheel
+    twine upload dist/*
 
 
 .. _virtualenv: https://pypi.python.org/pypi/virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,6 @@ nosenicedots >= 0.5
 # For documentation.
 Sphinx >= 1.2.1
 sphinx-rtd-theme >= 0.1.5
+
+# For publishing to PyPI.
+twine >= 1.6.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
**1) Enable universal wheel creation by default.**

This saves having to pass `--universal` when creating wheels:
http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#universal-wheels

**2) Update the publishing instructions to use twine and generate wheels.**

The official Python packaging guidelines recommend using twine:
http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#upload-your-distributions

This avoids sending passwords over HTTP (when using Python <2.7.9) and has a few additional advantages:
https://github.com/pypa/twine#why-should-i-use-this

These instructions now also result in a wheel distribution being generated and uploaded to PyPI alongside the source distribution, which offers several advantages over it for compatible versions of pip:
http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#wheels
