### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ HawkREST
     :alt: Travis master branch status
 
 .. image:: https://readthedocs.org/projects/hawkrest/badge/?version=latest
-    :target: https://hawkrest.readthedocs.org/en/latest/?badge=latest
+    :target: https://hawkrest.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation status
 
 
@@ -22,4 +22,4 @@ HawkREST
 .. _`Hawk`: https://github.com/hueniverse/hawk
 .. _`Django Rest Framework`: http://django-rest-framework.org/
 
-Full documentation: https://hawkrest.readthedocs.org/
+Full documentation: https://hawkrest.readthedocs.io/

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -57,5 +57,5 @@ distribution and wheel::
 
 
 .. _virtualenv: https://pypi.python.org/pypi/virtualenv
-.. _tox: http://tox.readthedocs.org/
+.. _tox: https://tox.readthedocs.io/
 .. _`PyPI`: https://pypi.python.org/pypi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ HawkREST
     :alt: Travis master branch status
 
 .. image:: http://readthedocs.org/projects/hawkrest/badge/?version=latest
-    :target: http://hawkrest.readthedocs.org/en/latest/?badge=latest
+    :target: https://hawkrest.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation status
 
 Hawk lets two parties securely communicate with each other using
@@ -41,7 +41,7 @@ with the security aspects of Hawk.
 .. _`Hawk`: https://github.com/hueniverse/hawk
 .. _`HTTP MAC access authentication`: http://tools.ietf.org/html/draft-hammer-oauth-v2-mac-token-05
 .. _`OAuth 1.0`: http://tools.ietf.org/html/rfc5849
-.. _`mohawk security considerations`: http://mohawk.readthedocs.org/en/latest/security.html
+.. _`mohawk security considerations`: https://mohawk.readthedocs.io/en/latest/security.html
 
 .. _install:
 
@@ -67,7 +67,7 @@ The source code is available at https://github.com/kumar303/hawkrest
 
 .. _`Django`: https://www.djangoproject.com/
 .. _`Django Rest Framework`: http://django-rest-framework.org/
-.. _`mohawk`: http://mohawk.readthedocs.org/
+.. _`mohawk`: https://mohawk.readthedocs.io/
 .. _`pip`: http://www.pip-installer.org/
 .. _`requirements`: http://www.pip-installer.org/en/latest/user_guide.html#requirements-files
 
@@ -136,7 +136,7 @@ Changelog
 - **0.0.4** (2015-06-24)
 
   - Fixed nonce callback support for
-    `mohawk 0.3.0 <http://mohawk.readthedocs.org/en/latest/#changelog>`_.
+    `mohawk 0.3.0 <https://mohawk.readthedocs.io/en/latest/#changelog>`_.
     Thanks to Josh Wilson for the patches.
 
 - **0.0.3** (2015-01-05)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,7 +101,7 @@ for some reason, set this:
     USE_CACHE_FOR_HAWK_NONCE = False  # only disable this if you need to
 
 .. _`memcache`: https://docs.djangoproject.com/en/dev/topics/cache/#memcached
-.. _`prevent replay attacks`: http://mohawk.readthedocs.org/en/latest/usage.html#using-a-nonce-to-prevent-replay-attacks
+.. _`prevent replay attacks`: https://mohawk.readthedocs.io/en/latest/usage.html#using-a-nonce-to-prevent-replay-attacks
 
 
 .. _protecting-api-views:

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# For info on tox see http://tox.readthedocs.org/
+# For info on tox see https://tox.readthedocs.io/
 
 [tox]
 # When updating the envlist, be sure to also update TOX_ENV in .travis.yml


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
