### PR TITLE
Green up Travis tests on master after mohawk and django-nose changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ python: "3.5"
 env:
     - TOX_ENV=docs
 
-    - TOX_ENV=py27-django1.6-drf3.2
-    - TOX_ENV=py27-django1.7-drf3.2
-    - TOX_ENV=py27-django1.7-drf3.3
     - TOX_ENV=py27-django1.8-drf3.2
     - TOX_ENV=py27-django1.8-drf3.3
     - TOX_ENV=py27-django1.9-drf3.3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Installation
 Requirements:
 
 * Python 2.7+ or 3.4+
-* `Django`_ 1.6 through 1.9
+* `Django`_ 1.8 through 1.9
 * `Django Rest Framework`_ 3.2 or 3.3
 * `mohawk`_
 (Older versions of these libraries may work, but support is not guaranteed.)
@@ -92,6 +92,10 @@ Changelog
     If you're upgrading from a version prior to 0.0.6, be sure to
     use ``rest_framework.permissions.IsAuthenticated`` on your views
     :ref:`as documented <protecting-api-views>`
+
+- **Unreleased**
+
+  - Dropped support for Django 1.6/1.7.
 
 - **0.0.10** (2016-06-01)
 

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,4 @@ setup(name='hawkrest',
           'Topic :: Internet :: WWW/HTTP',
       ],
       packages=find_packages(exclude=['tests']),
-      install_requires=['djangorestframework', 'mohawk>=0.3.0'])
+      install_requires=['djangorestframework', 'mohawk>=0.3.3'])

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -45,7 +45,7 @@ class AuthTest(BaseTest):
     def assert_log_regex(self, method, pattern):
         log_call = getattr(self.mock_log, method).call_args[0][0]
         assert re.search(pattern, log_call), (
-            'Unexpected call: log.{}("{}")'.format(method, log_call))
+            'Expected log.{}() matching "{}", saw: "{}"'.format(method, pattern, log_call))
 
 
 class TestAuthentication(AuthTest):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -106,7 +106,7 @@ class TestAuthentication(AuthTest):
         self.assertRaisesRegexp(AuthenticationFailed,
                                 '^Hawk authentication failed$',
                                 lambda: self.auth.authenticate(req))
-        self.assert_log_regex('warning', '^access denied: MacMismatch: ')
+        self.assert_log_regex('warning', '^access denied: MisComputedContentHash: ')
 
     def test_hawk_get_wrong_sig(self):
         sender = self._sender(url='http://realsite.com')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.http import HttpResponse
 
 import mock
-from mohawk.exc import MacMismatch
+from mohawk.exc import MisComputedContentHash
 from mohawk import Receiver
 
 from hawkrest import lookup_credentials
@@ -57,7 +57,7 @@ class TestMiddleware(BaseTest):
 
         response.content = 'TAMPERED WITH'
 
-        with self.assertRaises(MacMismatch):
+        with self.assertRaises(MisComputedContentHash):
             self.accept_response(res, sender)
 
     def test_respond_with_bad_content_type(self):
@@ -68,5 +68,5 @@ class TestMiddleware(BaseTest):
 
         response['Content-Type'] = 'TAMPERED WITH'
 
-        with self.assertRaises(MacMismatch):
+        with self.assertRaises(MisComputedContentHash):
             self.accept_response(res, sender)

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@
 # When updating the envlist, be sure to also update TOX_ENV in .travis.yml
 envlist =
     docs,
-    py27-django1.6-drf3.2,
-    py27-django1.7-drf{3.2,3.3},
     {py27,py34,py35}-django1.8-drf{3.2,3.3}
     # Django 1.9 requires DRF >= 3.3
     {py27,py34,py35}-django1.9-drf3.3
@@ -13,8 +11,6 @@ envlist =
 [testenv]
 commands = {envpython} runtests.py []
 deps =
-    django1.6: Django>=1.6,<1.7
-    django1.7: Django>=1.7,<1.8
     django1.8: Django>=1.8,<1.9
     django1.9: Django>=1.9,<1.10
     drf3.2: djangorestframework>=3.2,<3.3


### PR DESCRIPTION
**1) Improve the assert_log_regex() assertion message**
Since previously it didn't make expected vs actual clear.

**2) Fix tests for changes in mohawk 0.3.3**
Several cases that would have previously raised `MacMismatch` now more correctly raise `MisComputedContentHash` after kumar303/mohawk#28.

This fixes the test failures seen locally and on Travis, due to the unpinned (as it should be) mohawk dependency in setup.py.

**3) Stop testing against Django 1.6/1.7**
Since they are no longer supported and there isn't a version of django-nose that supports both Django <1.8 and Django 1.10. There are only two Mozilla properties that are on Django <1.8 that use hawkrest, and neither is actively maintained, so is unlikely to update to newer hawkrest in the future anyway.

To green up Travis it wasn't necessary to pin the dependencies in dev,txt, though that's likely worth doing at some point.

Fixes #27.

My next PR will add testing against newer Django, d-r-f and Python versions.