### PR TITLE
Django 1.11 middleware compatibility fix

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,7 +20,8 @@ Make sure the module is installed as an app:
         'hawkrest',
     )
 
-Make sure the middleware is installed:
+Make sure the middleware is installed by adding it to your ``MIDDLEWARE``
+(Django >= 1.11) or ``MIDDLEWARE_CLASSES setting``:
 
 .. code-block:: python
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,12 +20,12 @@ Make sure the module is installed as an app:
         'hawkrest',
     )
 
-Make sure the middleware is installed by adding it to your ``MIDDLEWARE``
-(Django >= 1.11) or ``MIDDLEWARE_CLASSES setting``:
+Make sure the middleware is installed by adding it to your project's
+``MIDDLEWARE`` or ``MIDDLEWARE_CLASSES`` (Django version < 1.11) setting:
 
 .. code-block:: python
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         ...
         'hawkrest.middleware.HawkResponseMiddleware',
     )

--- a/hawkrest/middleware.py
+++ b/hawkrest/middleware.py
@@ -1,11 +1,17 @@
 import logging
 
-from django.utils.deprecation import MiddlewareMixin
+try:
+    from django.utils.deprecation import MiddlewareMixin
+    middleware_cls = MiddlewareMixin
+except ImportError:
+    # Django version < 1.11
+    middleware_cls = object
+
 
 log = logging.getLogger(__name__)
 
 
-class HawkResponseMiddleware(MiddlewareMixin):
+class HawkResponseMiddleware(middleware_cls):
 
     def process_response(self, request, response):
         is_hawk_request = False

--- a/hawkrest/middleware.py
+++ b/hawkrest/middleware.py
@@ -3,8 +3,7 @@ import logging
 try:
     from django.utils.deprecation import MiddlewareMixin
     middleware_cls = MiddlewareMixin
-except ImportError:
-    # Django version < 1.11
+except ImportError:  # Django version < 1.11
     middleware_cls = object
 
 

--- a/hawkrest/middleware.py
+++ b/hawkrest/middleware.py
@@ -1,9 +1,11 @@
 import logging
 
+from django.utils.deprecation import MiddlewareMixin
+
 log = logging.getLogger(__name__)
 
 
-class HawkResponseMiddleware:
+class HawkResponseMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         is_hawk_request = False

--- a/hawkrest/middleware.py
+++ b/hawkrest/middleware.py
@@ -15,7 +15,6 @@ class HawkResponseMiddleware(middleware_cls):
 
     def process_response(self, request, response):
         is_hawk_request = False
-        hawk_auth_was_processed = False
         if request.META.get('HTTP_AUTHORIZATION', '').startswith('Hawk'):
             is_hawk_request = True
 


### PR DESCRIPTION
Short-term patch for #38.

Enables compatibility with old/new style middleware. Allows use of `MIDDLEWARE` or `MIDDLEWARE_CLASSES` in Django settings. Includes appropriate update to the documentation.